### PR TITLE
Remove argparse

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,6 @@ setup(
 
     install_requires=[
         "pyshark",
-        "argparse",
         "argcomplete"
     ],
 


### PR DESCRIPTION
[`argparse`](https://docs.python.org/3/library/argparse.html) is a standard module.