### PR TITLE
Add license tag

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setup(
     long_description=long_description,
     long_description_content_type='text/markdown',
     keywords="credentials security networking extraction mining wireshark tshark dissector password",
+    license="GPLv3",
     author='ShellCode',
     author_email='shellcode33@protonmail.ch',
     url='https://github.com/ShellCode33/CredSLayer',


### PR DESCRIPTION
Allows third-party tools (e.g., PyPI) to get the used license.