### PR TITLE
Remove shebang

### DIFF
--- a/credslayer/credslayer.py
+++ b/credslayer/credslayer.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python3
 # coding: utf-8
 
 import socket


### PR DESCRIPTION
This file is not executed directly, thus the shebang is not needed.

Another issue that came up during the Fedora package review.

